### PR TITLE
Queue rework

### DIFF
--- a/src/commands/admin/addcaptains.js
+++ b/src/commands/admin/addcaptains.js
@@ -17,7 +17,7 @@ module.exports = class AddCaptainsCommand extends Command {
 	}
 	run(message) {
 		try {
-			queue.mainQueue.addCaptains(message.mentions.users);
+			queue.mainQueue.setCaptains(message.mentions.users.array());
 		}
 		catch (error) {
 			message.reply(error);

--- a/src/commands/admin/addplayers.js
+++ b/src/commands/admin/addplayers.js
@@ -17,7 +17,7 @@ module.exports = class AddPlayersCommand extends Command {
 	}
 	run(message) {
 		try {
-			queue.mainQueue.addPlayers(message.mentions.users);
+			queue.mainQueue.addPlayers(message.mentions.users.array());
 		}
 		catch (error) {
 			message.reply(error);

--- a/src/commands/admin/list.js
+++ b/src/commands/admin/list.js
@@ -16,6 +16,6 @@ module.exports = class ListCommand extends Command {
 		return util.isAuthorizedMessage(message);
 	}
 	run(message) {
-		message.say('Captains: ' + queue.mainQueue.getReadableCaptainList() + '\nPlayers: ' + queue.mainQueue.getReadablePlayerList());
+		message.say('Captains: ' + queue.mainQueue.getReadableCaptainList() + '\nPlayers: ' + queue.mainQueue.getReadableNonCaptainList());
 	}
 };

--- a/src/commands/admin/removecaptains.js
+++ b/src/commands/admin/removecaptains.js
@@ -17,7 +17,7 @@ module.exports = class RemoveCaptainsCommand extends Command {
 	}
 	run(message) {
 		try {
-			queue.mainQueue.removeCaptains(message.mentions.users);
+			queue.mainQueue.unsetCaptains(message.mentions.users.array());
 		}
 		catch (error) {
 			message.reply(error);

--- a/src/commands/admin/removeplayers.js
+++ b/src/commands/admin/removeplayers.js
@@ -17,7 +17,7 @@ module.exports = class RemovePlayersCommand extends Command {
 	}
 	run(message) {
 		try {
-			queue.mainQueue.removePlayers(message.mentions.users);
+			queue.mainQueue.removePlayers(message.mentions.users.array());
 		}
 		catch (error) {
 			message.reply(error);


### PR DESCRIPTION
Draft to discuss proposed changes for the list redesign outlined in #21

Major changes
- Added Player class. Right now the player class contains a reference to the discord.js user as well as if the player is a captain.
- Updated Queue to use Player class internally. All calls to the Queue class expect Discord.js users as parameter the Player class is only used internally. (The static `distributePlayers(...)` function still uses the old discord Users. The Players are converted in the non static `distribute()` function. I have not changed much in the `distributePlayers(...)` function since we might want to rework that one separately)
- Updated the function name `addCaptain[s](user)` and `removeCaptain[s](users)` to `setCaptain[s](user)` and `unsetCaptain[s](users)` to better reflect the new implementation of a unified player list. The commands have not been renamed yet though we might want to change that as well.


Minor changes:
- Updated the `distributePlayers(...)` function to use the `util.convertIdToTag(id)` instead of hard coding.
  
Closes: #21 